### PR TITLE
Fix crash when opening app after activity is destroyed while service is running

### DIFF
--- a/app/src/main/java/io/nekohasekai/sfa/ui/main/DashboardFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/ui/main/DashboardFragment.kt
@@ -50,11 +50,6 @@ class DashboardFragment : Fragment(), CommandClientHandler {
         return binding.root
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        if (_binding != null) onCreate()
-    }
-
     private fun onCreate() {
         val activity = activity ?: return
 
@@ -144,10 +139,7 @@ class DashboardFragment : Fragment(), CommandClientHandler {
         disconnect()
     }
 
-    private var connected = false
-
     override fun connected() {
-        connected = true
         val binding = _binding ?: return
         lifecycleScope.launch(Dispatchers.Main) {
             binding.memoryText.text = getString(R.string.loading)
@@ -156,7 +148,6 @@ class DashboardFragment : Fragment(), CommandClientHandler {
     }
 
     override fun disconnected(message: String?) {
-        connected = false
         val binding = _binding ?: return
         lifecycleScope.launch(Dispatchers.Main) {
             binding.memoryText.text = getString(R.string.loading)
@@ -172,13 +163,6 @@ class DashboardFragment : Fragment(), CommandClientHandler {
         lifecycleScope.launch(Dispatchers.Main) {
             binding.memoryText.text = Libbox.formatBytes(message.memory)
             binding.goroutinesText.text = message.goroutines.toString()
-        }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        if (!connected) {
-            reconnect()
         }
     }
 


### PR DESCRIPTION
From my testing, the crash is caused by the `reconnect` in onResume (because of race condition?). When switching view using bottom navigation, connected will become true before onResume is called. But when starting the app after activity is killed, onResume will be called before connected becomes true.

I've been running with the changes for a few days and there is no crash anymore. Memory and goroutines statistics updates correctly.

There is no need to reconnect in `onResume`. If LiveData already has data set, it will be delivered to the observer when adding the observer. So it will automatically reconnect in `onViewCreated` if service is started.

And there is no need to check if binding is not null on fragment create, it will always be null at that time.

Please correct me if I got something wrong. Thanks.