### PR TITLE
Fixes for AppChangeReceiver

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -138,10 +138,6 @@
             </intent-filter>
         </receiver>
 
-        <receiver
-            android:name="io.nekohasekai.sfa.bg.AppChangeReceiver"
-            android:exported="true" />
-
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.cache"

--- a/app/src/main/java/io/nekohasekai/sfa/bg/AppChangeReceiver.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/bg/AppChangeReceiver.kt
@@ -24,7 +24,7 @@ class AppChangeReceiver : BroadcastReceiver() {
             return
         }
         val perAppProxyUpdateOnChange = Settings.perAppProxyUpdateOnChange
-        if (perAppProxyUpdateOnChange != Settings.PER_APP_PROXY_DISABLED) {
+        if (perAppProxyUpdateOnChange == Settings.PER_APP_PROXY_DISABLED) {
             Log.d(TAG, "update on change disabled")
             return
         }


### PR DESCRIPTION
- Fix disabled state check
- Remove it from manifest as there is no need to register in manifest