### PR TITLE
Fix compatibility with Android 14

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace 'io.nekohasekai.sfa'
-    compileSdk 33
+    compileSdk 34
 
     ksp {
         arg("room.incremental", "true")
@@ -60,13 +60,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     buildFeatures {
         viewBinding true
         aidl true
     }
 
-    applicationVariants.all { variant ->
-        variant.outputs.all {
+    applicationVariants.configureEach { variant ->
+        variant.outputs.configureEach {
             outputFileName = (outputFileName as String).replace("-release", "")
         }
     }
@@ -102,13 +103,7 @@ dependencies {
     implementation('org.smali:dexlib2:2.5.2') {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    implementation('com.google.guava:guava:32.1.1-android')
-    // ref: https://github.com/google/guava/releases/tag/v32.1.0#user-content-duplicate-ListenableFuture
-    modules {
-        module("com.google.guava:listenablefuture") {
-            replacedBy("com.google.guava:guava", "listenablefuture is part of guava")
-        }
-    }
+    implementation('com.google.guava:guava:32.1.2-android')
 }
 
 if (getProps("APPCENTER_TOKEN") != "") {
@@ -140,10 +135,10 @@ def getProps(String propName) {
         props.load(new FileInputStream(propsFile))
         String value = props[propName]
         if (value == null) {
-            return "";
+            return ""
         }
         return value
     } else {
-        return "";
+        return ""
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
@@ -120,14 +121,23 @@
         <service
             android:name=".bg.VPNService"
             android:exported="false"
+            android:foregroundServiceType="specialUse"
             android:permission="android.permission.BIND_VPN_SERVICE">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="vpn" />
         </service>
         <service
             android:name=".bg.ProxyService"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="proxy" />
+        </service>
 
         <receiver
             android:name=".bg.BootReceiver"

--- a/app/src/main/java/io/nekohasekai/sfa/bg/BoxService.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/bg/BoxService.kt
@@ -235,10 +235,10 @@ class BoxService(
         status.value = Status.Starting
 
         if (!receiverRegistered) {
-            service.registerReceiver(receiver, IntentFilter().apply {
+            ContextCompat.registerReceiver(service, receiver, IntentFilter().apply {
                 addAction(Action.SERVICE_CLOSE)
                 addAction(Action.SERVICE_RELOAD)
-            })
+            }, ContextCompat.RECEIVER_NOT_EXPORTED)
             receiverRegistered = true
         }
 


### PR DESCRIPTION
- Update compileSdk to 34
- Fix crash on Android 14
  - https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported
  - https://developer.android.com/about/versions/14/changes/fgs-types-required
- Update guava to 32.1.2, removing the listenablefuture workaround