### PR TITLE
Improve permission request and description dialog

### DIFF
--- a/app/src/main/java/io/nekohasekai/sfa/bg/BoxService.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/bg/BoxService.kt
@@ -5,7 +5,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.pm.PackageManager
 import android.os.Build
 import android.os.IBinder
 import android.os.ParcelFileDescriptor
@@ -27,6 +26,7 @@ import io.nekohasekai.sfa.constant.Alert
 import io.nekohasekai.sfa.constant.Status
 import io.nekohasekai.sfa.database.ProfileManager
 import io.nekohasekai.sfa.database.Settings
+import io.nekohasekai.sfa.ktx.hasPermission
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
@@ -174,10 +174,7 @@ class BoxService(
                 } else {
                     android.Manifest.permission.ACCESS_BACKGROUND_LOCATION
                 }
-                if (ContextCompat.checkSelfPermission(
-                        service, wifiPermission
-                    ) != PackageManager.PERMISSION_GRANTED
-                ) {
+                if (!service.hasPermission(wifiPermission)) {
                     newService.close()
                     stopAndAlert(Alert.RequestLocationPermission)
                     return

--- a/app/src/main/java/io/nekohasekai/sfa/ktx/Context.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/ktx/Context.kt
@@ -1,0 +1,9 @@
+package io.nekohasekai.sfa.ktx
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+
+fun Context.hasPermission(permission: String): Boolean {
+    return ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
     <string name="app_name">sing-box</string>
 
     <string name="stop">Stop</string>
-    <string name="ok">Ok</string>
+    <string name="ok">OK</string>
     <string name="no_thanks">No, thanks</string>
 
     <string name="title_dashboard">Dashboard</string>
@@ -146,6 +146,8 @@
     <string name="other_methods">Other methods</string>
     <string name="action_start">Start</string>
     <string name="location_permission_title">Location permission</string>
-    <string name="location_permission_description">sing-box uses the **background location** permission to implement the `wifi_ssid` and `wifi_bssid` routing rule items that **you are using**.</string>
-
+    <string name="location_permission_description"><![CDATA[sing-box uses the <strong>location</strong> permission to implement the <strong><tt>wifi_ssid</tt> and <tt>wifi_bssid</tt> routing rules</strong> that <strong>you are using</strong>. Please grant the permission.]]></string>
+    <string name="location_permission_background_description"><![CDATA[On Android 10 and up, <strong>background location</strong> permission is required. Please select <strong>Allow all the time</strong> to grant the permission.]]></string>
+    <string name="location_permission_denied_description"><![CDATA[It looks like you have denied the required permission. To continue using the app, please <strong>grant the permission</strong> or <strong>remove <tt>wifi_ssid</tt> and <tt>wifi_bssid</tt> routing rules</strong> from your profile.]]></string>
+    <string name="open_settings">Open Settings</string>
 </resources>


### PR DESCRIPTION
- Prefer the standard way to request permissions
- Use HTML to format text in dialogs
- Replace `ContextCompat.checkSelfPermission` with Kotlin extension function
- Use standard capitalization for "OK"