### PR TITLE
remove unnecessary addRoute

### DIFF
--- a/app/src/main/java/io/nekohasekai/sfa/bg/VPNService.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/bg/VPNService.kt
@@ -84,8 +84,6 @@ class VPNService : VpnService(), PlatformInterfaceWrapper {
                     while (inet4RouteAddress.hasNext()) {
                         builder.addRoute(inet4RouteAddress.next().toIpPrefix())
                     }
-                } else {
-                    builder.addRoute("0.0.0.0", 0)
                 }
 
                 val inet6RouteAddress = options.inet6RouteAddress
@@ -93,8 +91,6 @@ class VPNService : VpnService(), PlatformInterfaceWrapper {
                     while (inet6RouteAddress.hasNext()) {
                         builder.addRoute(inet6RouteAddress.next().toIpPrefix())
                     }
-                } else {
-                    builder.addRoute("::", 0)
                 }
 
                 val inet4RouteExcludeAddress = options.inet4RouteExcludeAddress


### PR DESCRIPTION
As documented in https://developer.android.com/reference/android/net/VpnService.Builder#allowFamily(int), by default, if no address, route or DNS server of a specific family (IPv4 or IPv6) is added to this VPN, then all outgoing traffic of that family is blocked. (rather than bypassing the VPN)

I only tested this on UpsideDownCake.