### PR TITLE
Fix system bars color on Android 13 and below

### DIFF
--- a/app/src/main/java/io/nekohasekai/sfa/ui/shared/AbstractActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/ui/shared/AbstractActivity.kt
@@ -1,11 +1,14 @@
 package io.nekohasekai.sfa.ui.shared
 
+import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.view.WindowCompat
 import androidx.viewbinding.ViewBinding
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.color.DynamicColors
@@ -15,8 +18,7 @@ import io.nekohasekai.sfa.ui.MainActivity
 import io.nekohasekai.sfa.utils.MIUIUtils
 import java.lang.reflect.ParameterizedType
 
-abstract class AbstractActivity<Binding : ViewBinding>() :
-    AppCompatActivity() {
+abstract class AbstractActivity<Binding : ViewBinding> : AppCompatActivity() {
 
     private var _binding: Binding? = null
     internal val binding get() = _binding!!
@@ -26,10 +28,17 @@ abstract class AbstractActivity<Binding : ViewBinding>() :
 
         DynamicColors.applyToActivityIfAvailable(this)
 
-        val colorSurfaceContainer =
-            getAttrColor(com.google.android.material.R.attr.colorSurfaceContainer)
-        window.statusBarColor = colorSurfaceContainer
-        window.navigationBarColor = colorSurfaceContainer
+        // Set light navigation bar for Android 8.0
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O) {
+            val nightFlag = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+            if (nightFlag != Configuration.UI_MODE_NIGHT_YES) {
+                val insetsController = WindowCompat.getInsetsController(
+                    window,
+                    window.decorView
+                )
+                insetsController.isAppearanceLightNavigationBars = true
+            }
+        }
 
         _binding = createBindingInstance(layoutInflater).also {
             setContentView(it.root)

--- a/app/src/main/res/values-night-v23/themes.xml
+++ b/app/src/main/res/values-night-v23/themes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="AppTheme.Base.V23" />
+
+    <style name="AppTheme.Base.V23.Night" parent="AppTheme.Base.V23">
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values-night-v26/themes.xml
+++ b/app/src/main/res/values-night-v26/themes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="AppTheme.Base.V26.Night" />
+
+    <style name="AppTheme.Base.V26.Night" parent="AppTheme.Base.V26">
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,8 +1,0 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-
-    <style name="AppTheme" parent="AppTheme.Base">
-        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="m">false</item>
-    </style>
-
-</resources>

--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="AppTheme.Base.V23" />
+
+    <style name="AppTheme.Base.V23" parent="AppTheme.Base">
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:statusBarColor">?attr/colorSurfaceContainer</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values-v26/themes.xml
+++ b/app/src/main/res/values-v26/themes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="AppTheme.Base.V26" />
+
+    <style name="AppTheme.Base.V26" parent="AppTheme.Base.V23">
+        <item name="android:navigationBarColor">?attr/colorSurfaceContainer</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values-v27/themes.xml
+++ b/app/src/main/res/values-v27/themes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="AppTheme.Base.V27" />
+
+    <style name="AppTheme.Base.V27" parent="AppTheme.Base.V26">
+        <item name="android:windowLightNavigationBar">true</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,9 +1,7 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
 
-    <style name="AppTheme" parent="AppTheme.Base">
-        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="m">true</item>
-    </style>
+    <style name="AppTheme" parent="AppTheme.Base" />
 
     <style name="AppTheme.Base" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="bottomSheetDialogTheme">@style/BottomSheetDialogTheme</item>


### PR DESCRIPTION
It seems that `getAttrColor` doesn't work properly on Android 13 and below (or Android 12, probably because dynamic color introduced in Android 12). Here is a screenshot I got from a user:

![photo_2024-09-12_00-18-54](https://github.com/user-attachments/assets/46000a99-65e6-4b45-b417-53ed5cba69a5)

This PR fixes status bar and navigation bar color issue using style xmls.

Considering light status bar is not supported on Android 5.x and light navigation bar is not supported on Android 7.x and below, and to maintain status bar and navigation bar visibility:

- On Android 5.x, default colors are used (primary theme color for status bar and black for navigation bar)
- On Android 6.x and 7.x, default navigation bar color is used (black)

Android 8.0 supports light navigation bar but not via style xml, so a special check is added to set light navigation bar for it.