### PR TITLE
Fix FragmentStateAdapter recreates Fragments

### DIFF
--- a/app/src/main/java/io/nekohasekai/sfa/ui/dashboard/GroupsFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/ui/dashboard/GroupsFragment.kt
@@ -69,6 +69,7 @@ class GroupsFragment : Fragment(), CommandClient.Handler {
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
+        commandClient.disconnect()
     }
 
     private var displayed = false

--- a/app/src/main/java/io/nekohasekai/sfa/ui/main/DashboardFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/ui/main/DashboardFragment.kt
@@ -40,10 +40,11 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         return binding.root
     }
 
+    private val adapter by lazy { Adapter(this) }
     private fun onCreate() {
         val activity = activity ?: return
         val binding = binding ?: return
-        binding.dashboardPager.adapter = Adapter(this)
+        binding.dashboardPager.adapter = adapter
         binding.dashboardPager.offscreenPageLimit = Page.values().size
         activity.serviceStatus.observe(viewLifecycleOwner) {
             when (it) {
@@ -107,6 +108,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         super.onDestroyView()
         mediator?.detach()
         mediator = null
+        binding?.dashboardPager?.adapter = null
         binding = null
     }
 


### PR DESCRIPTION
在SFA中发现了一个问题：

- 测试设备：MI 6X / MIUI 12 / Android 9
- 应用版本：v1.11.1
- 配置文件：任意，`{}`（空配置）都可以
- 复现方法：启动服务后，在`仪表`和`日志`页间反复切换
- 问题现象：`goroutine`数持续异常上涨

排查后发现，这个问题的原因是`DashboardFragment.Adapter`（派生自`FragmentStateAdapter`）泄漏导致的`Fragment`重叠。

具体来说，`DashboardFragment`在`onCreateView`中实例化了`Adapter`，后者实例化了`OverviewFragment`和`GroupsFragment`。而在`DashboardFragment.onDestroyView`中，`binding = null`仅销毁了`Adapter`实例，并未销毁`OverviewFragment`和`GroupsFragment`实例，后者仍存在于`DashboardFragment`的`childFragmentManager`中。切回`仪表`页时，`DashboardFragment.onCreateView`再次实例化了`Adapter`、`OverviewFragment`和`GroupsFragment`，导致新旧`Fragment`重叠存在，它们同时调用`onCreateView`，创建了大量`goroutine`。

解决方法有两个思路：

- 思路1：从`仪表`页面切走时销毁`Fragment`，切回时新建`Fragment`。这需要在`DashboardFragment.onDestroyView`中显式销毁`childFragmentManager`里的`OverviewFragment`和`GroupsFragment`实例，或者在此时直接销毁`DashboardFragment`实例。
- 思路2：从`仪表`页面切走时不销毁`Fragment`，切回时复用`Fragment`。这需要`Adapter`只被实例化一次，切回`仪表`页时复用。（我在想`binding`和`mediator`是否也可以不被销毁，而被复用？）

不知repo的owner更倾向于哪种方案，本PR实现的是第2种方案。