### PR TITLE
Add download manager in skip prefix list

### DIFF
--- a/app/src/main/java/io/nekohasekai/sfa/ui/profileoverride/PerAppProxyActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/ui/profileoverride/PerAppProxyActivity.kt
@@ -635,6 +635,7 @@ class PerAppProxyActivity : AbstractActivity<ActivityPerAppProxyBinding>() {
             "com.microsoft",
             "com.apple",
             "com.zhiliaoapp.musically", // Banned by China
+            "com.android.providers.downloads",
         )
 
         private val chinaAppPrefixList = listOf(


### PR DESCRIPTION
Download manager may be added China SDK by particular vendor, being regarded as China app.