### PR TITLE
Add start/stop shortcuts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,14 +103,30 @@
             android:name=".ui.ShortcutActivity"
             android:excludeFromRecents="true"
             android:exported="true"
-            android:label="@string/quick_toggle"
+            android:label="@string/title_shortcuts"
+            android:icon="@mipmap/ic_launcher"
             android:launchMode="singleTask"
             android:taskAffinity=""
             android:theme="@style/AppTheme.Translucent">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="io.nekohasekai.sfa.QUICK_TOGGLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="io.nekohasekai.sfa.QUICK_START" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="io.nekohasekai.sfa.QUICK_STOP" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
+
         <activity
             android:name="io.nekohasekai.sfa.ui.profile.NewProfileActivity"
             android:exported="false" />

--- a/app/src/main/java/io/nekohasekai/sfa/constant/Action.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/constant/Action.kt
@@ -4,4 +4,8 @@ object Action {
     const val SERVICE = "io.nekohasekai.sfa.SERVICE"
     const val SERVICE_CLOSE = "io.nekohasekai.sfa.SERVICE_CLOSE"
     const val OPEN_URL = "io.nekohasekai.sfa.SERVICE_OPEN_URL"
+
+    const val QUICK_TOGGLE = "io.nekohasekai.sfa.QUICK_TOGGLE"
+    const val QUICK_START = "io.nekohasekai.sfa.QUICK_START"
+    const val QUICK_STOP = "io.nekohasekai.sfa.QUICK_STOP"
 }

--- a/app/src/main/java/io/nekohasekai/sfa/ui/ShortcutActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sfa/ui/ShortcutActivity.kt
@@ -1,6 +1,7 @@
 package io.nekohasekai.sfa.ui
 
 import android.app.Activity
+import android.app.AlertDialog
 import android.content.Intent
 import android.content.pm.ShortcutManager
 import android.os.Build
@@ -12,49 +13,80 @@ import androidx.core.graphics.drawable.IconCompat
 import io.nekohasekai.sfa.R
 import io.nekohasekai.sfa.bg.BoxService
 import io.nekohasekai.sfa.bg.ServiceConnection
+import io.nekohasekai.sfa.constant.Action
 import io.nekohasekai.sfa.constant.Status
 
 class ShortcutActivity : Activity(), ServiceConnection.Callback {
-
     private val connection = ServiceConnection(this, this, false)
+    private var pendingAction: String? = null
+
+    private data class Shortcut(val label: String, val action: String, val icon: Int)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (intent.action == Intent.ACTION_CREATE_SHORTCUT) {
-            setResult(
-                RESULT_OK, ShortcutManagerCompat.createShortcutResultIntent(
-                    this,
-                    ShortcutInfoCompat.Builder(this, "toggle")
-                        .setIntent(
-                            Intent(
-                                this,
-                                ShortcutActivity::class.java
-                            ).setAction(Intent.ACTION_MAIN)
-                        )
-                        .setIcon(
-                            IconCompat.createWithResource(
-                                this,
-                                R.mipmap.ic_launcher
-                            )
-                        )
-                        .setShortLabel(getString(R.string.quick_toggle))
-                        .build()
-                )
-            )
+        when (intent.action) {
+            Intent.ACTION_CREATE_SHORTCUT -> showShortcutDialog()
+            Action.QUICK_TOGGLE, Action.QUICK_START, Action.QUICK_STOP -> {
+                pendingAction = intent.action
+                connection.connect()
+                reportShortcutUsed()
+            }
+
+            else -> finish()
+        }
+    }
+
+    private fun showShortcutDialog() {
+        val shortcuts = listOf(
+            Shortcut(getString(R.string.quick_toggle), Action.QUICK_TOGGLE, R.mipmap.ic_launcher),
+            Shortcut(getString(R.string.quick_start), Action.QUICK_START, R.mipmap.ic_launcher),
+            Shortcut(getString(R.string.quick_stop), Action.QUICK_STOP, R.mipmap.ic_launcher)
+        )
+
+        val labels = shortcuts.map { it.label }.toTypedArray()
+
+        val itemClickListener = { _: android.content.DialogInterface, index: Int ->
+            val shortcut = shortcuts[index]
+            val shortcutIntent = Intent(this, ShortcutActivity::class.java).apply {
+                action = shortcut.action
+            }
+            val shortcutInfo =
+                ShortcutInfoCompat
+                    .Builder(this, shortcut.action)
+                    .setIntent(shortcutIntent)
+                    .setIcon(IconCompat.createWithResource(this, shortcut.icon))
+                    .setShortLabel(shortcut.label)
+                    .build()
+            val resultIntent = ShortcutManagerCompat.createShortcutResultIntent(this, shortcutInfo)
+            setResult(RESULT_OK, resultIntent)
             finish()
-        } else {
-            connection.connect()
-            if (Build.VERSION.SDK_INT >= 25) {
-                getSystemService<ShortcutManager>()?.reportShortcutUsed("toggle")
+        }
+
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.title_shortcuts))
+            .setItems(labels, itemClickListener)
+            .setOnCancelListener { finish() }
+            .show()
+    }
+
+    private fun reportShortcutUsed() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            pendingAction?.let {
+                getSystemService<ShortcutManager>()?.reportShortcutUsed(it)
             }
         }
     }
 
     override fun onServiceStatusChanged(status: Status) {
-        when (status) {
-            Status.Started -> BoxService.stop()
-            Status.Stopped -> BoxService.start()
-            else -> {}
+        when (pendingAction) {
+            Action.QUICK_TOGGLE -> when (status) {
+                Status.Started -> BoxService.stop()
+                Status.Stopped -> BoxService.start()
+                else -> {}
+            }
+
+            Action.QUICK_START -> if (status == Status.Stopped) BoxService.start()
+            Action.QUICK_STOP -> if (status == Status.Started) BoxService.stop()
         }
         finish()
     }
@@ -63,5 +95,4 @@ class ShortcutActivity : Activity(), ServiceConnection.Callback {
         connection.disconnect()
         super.onDestroy()
     }
-
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -12,7 +12,10 @@
     <string name="title_overview">概述</string>
     <string name="title_groups">组</string>
     <string name="title_debug">调试</string>
+    <string name="title_shortcuts">快捷操作</string>
     <string name="quick_toggle">切换</string>
+    <string name="quick_start">启动</string>
+    <string name="quick_stop">停止</string>
     <string name="profile_name">名称</string>
     <string name="profile_type">类型</string>
     <string name="profile_source">源</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,8 +15,11 @@
     <string name="title_overview">Overview</string>
     <string name="title_groups">Groups</string>
     <string name="title_debug">Debug</string>
+    <string name="title_shortcuts">Quick Actions</string>
 
     <string name="quick_toggle">Toggle</string>
+    <string name="quick_start">Start</string>
+    <string name="quick_stop">Stop</string>
     <string name="profile_name">Name</string>
     <string name="profile_type">Type</string>
     <string name="profile_source">Source</string>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -6,7 +6,27 @@
         android:shortcutLongLabel="@string/quick_toggle"
         android:shortcutShortLabel="@string/quick_toggle">
         <intent
-            android:action="android.intent.action.MAIN"
+            android:action="io.nekohasekai.sfa.QUICK_TOGGLE"
+            android:targetClass="io.nekohasekai.sfa.ui.ShortcutActivity"
+            android:targetPackage="io.nekohasekai.sfa" />
+    </shortcut>
+    <shortcut
+        android:icon="@mipmap/ic_launcher"
+        android:shortcutId="start"
+        android:shortcutLongLabel="@string/quick_start"
+        android:shortcutShortLabel="@string/quick_start">
+        <intent
+            android:action="io.nekohasekai.sfa.QUICK_START"
+            android:targetClass="io.nekohasekai.sfa.ui.ShortcutActivity"
+            android:targetPackage="io.nekohasekai.sfa" />
+    </shortcut>
+    <shortcut
+        android:icon="@mipmap/ic_launcher"
+        android:shortcutId="stop"
+        android:shortcutLongLabel="@string/quick_stop"
+        android:shortcutShortLabel="@string/quick_stop">
+        <intent
+            android:action="io.nekohasekai.sfa.QUICK_STOP"
             android:targetClass="io.nekohasekai.sfa.ui.ShortcutActivity"
             android:targetPackage="io.nekohasekai.sfa" />
     </shortcut>


### PR DESCRIPTION
I've added shortcuts to start and stop Sing-box, so they can be used to automate workflows with Samsung Routines and similar automation tools that use shortcuts as actions.

I would be grateful for any corrections, since I have no experience in Android/Kotlin development